### PR TITLE
Don't default to process.env.AXIOM_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,6 @@
 [![Latest Release][release_badge]][release]
 [![License][license_badge]][license]
 
----
-
-## Table of Contents
-
-1. [Introduction](#introduction)
-1. [Installation](#installation)
-1. [Authentication](#authentication)
-1. [Usage](#usage)
-1. [Documentation](#documentation)
-1. [Contributing](#contributing)
-1. [License](#license)
-
-## Introduction
-
 Axiom Node is a NodeJS package for accessing the [Axiom](https://www.axiom.co/)
 API.
 
@@ -55,14 +41,20 @@ for.
 ## Usage
 
 ```ts
-// Export `AXIOM_TOKEN` and `AXIOM_ORG_ID` for Axiom Cloud
-// Export `AXIOM_URL` and `AXIOM_TOKEN` for Axiom Selfhost
+import Client, { CloudURL } from '@axiomhq/axiom-node';
 
-import Client from '@axiomhq/axiom-node';
+const token = process.env.AXIOM_TOKEN;
 
-const client = new Client();
+// For Axiom Cloud
+const orgId = process.env.AXIOM_ORG_ID;
+const client = new Client(CloudURL, token, orgId)
 
-// ...
+// For Axiom Selfhost
+const url = process.env.AXIOM_URL;
+const client = new Client(url, token);
+
+// List datasets
+const datasets = await client.datasets.list();
 ```
 
 For more sample code snippets, head over to the [examples](examples) directory.

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -22,7 +22,7 @@ export default class Client {
     version: version.Service;
     virtualFields: vfields.Service;
 
-    constructor(basePath?: string, accessToken?: string, orgID?: string) {
+    constructor(basePath: string, accessToken: string, orgID?: string) {
         this.datasets = new datasets.Service(basePath, accessToken, orgID);
         this.monitors = new monitors.Service(basePath, accessToken, orgID);
         this.notifiers = new notifiers.Service(basePath, accessToken, orgID);

--- a/lib/httpClient.ts
+++ b/lib/httpClient.ts
@@ -5,11 +5,7 @@ export const CloudURL = 'https://cloud.axiom.co';
 export default abstract class HTTPClient {
     protected readonly client: AxiosInstance;
 
-    constructor(
-        basePath: string = process.env.AXIOM_URL || CloudURL,
-        accessToken: string = process.env.AXIOM_TOKEN || '',
-        orgID: string = process.env.AXIOM_ORG_ID || '',
-    ) {
+    constructor(basePath: string, accessToken: string, orgID?: string) {
         this.client = axios.create({
             baseURL: basePath,
             timeout: 30000,

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -17,7 +17,7 @@ export namespace tokens {
     class Service extends HTTPClient {
         protected readonly localPath: string;
 
-        constructor(localPath: string, basePath?: string, accessToken?: string, orgID?: string) {
+        constructor(localPath: string, basePath: string, accessToken: string, orgID?: string) {
             super(basePath, accessToken, orgID);
 
             this.localPath = localPath;
@@ -52,7 +52,7 @@ export namespace tokens {
     }
 
     export class IngestService extends Service {
-        constructor(basePath?: string, accessToken?: string, orgID?: string) {
+        constructor(basePath: string, accessToken: string, orgID?: string) {
             super('/api/v1/tokens/ingest', basePath, accessToken, orgID);
         }
 
@@ -63,7 +63,7 @@ export namespace tokens {
     }
 
     export class PersonalService extends Service {
-        constructor(basePath?: string, accessToken?: string, orgID?: string) {
+        constructor(basePath: string, accessToken: string, orgID?: string) {
             super('/api/v1/tokens/personal', basePath, accessToken, orgID);
         }
     }

--- a/tests/integration/datasets.test.ts
+++ b/tests/integration/datasets.test.ts
@@ -1,13 +1,16 @@
 import { expect } from 'chai';
 import { gzip } from 'zlib';
 
-import { datasets } from '../../lib/datasets';
+import { CloudURL, datasets } from '../../lib';
 
 const datasetSuffix = process.env.AXIOM_DATASET_SUFFIX || 'local';
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('DatasetsService', () => {
     const datasetName = `test-axiom-node-dataset-${datasetSuffix}`;
-    const client = new datasets.Service();
+    const client = new datasets.Service(url, token, orgId);
 
     before(async () => {
         await client.create({

--- a/tests/integration/monitors.test.ts
+++ b/tests/integration/monitors.test.ts
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 
-import { datasets } from '../../lib/datasets';
-import { monitors } from '../../lib/monitors';
+import { CloudURL, datasets, monitors } from '../../lib';
 
 const datasetSuffix = process.env.AXIOM_DATASET_SUFFIX || 'local';
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('MonitorsService', () => {
     const datasetName = `test-axiom-node-monitors-${datasetSuffix}`;
-    const datasetsClient = new datasets.Service();
-    const client = new monitors.Service();
+    const datasetsClient = new datasets.Service(url, token, orgId);
+    const client = new monitors.Service(url, token, orgId);
 
     let monitor: monitors.Monitor;
 

--- a/tests/integration/notifiers.test.ts
+++ b/tests/integration/notifiers.test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 
-import { notifiers } from '../../lib/notifiers';
+import { CloudURL, notifiers } from '../../lib';
+
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('NotifiersService', () => {
-    const client = new notifiers.Service();
+    const client = new notifiers.Service(url, token, orgId);
 
     let notifier: notifiers.Notifier;
 

--- a/tests/integration/starred.test.ts
+++ b/tests/integration/starred.test.ts
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 
-import { datasets } from '../../lib/datasets';
-import { starred } from '../../lib/starred';
+import { CloudURL, datasets, starred } from '../../lib';
 
 const datasetSuffix = process.env.AXIOM_DATASET_SUFFIX || 'local';
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('StarredQueriesService', () => {
     const datasetName = `test-axiom-node-starred-queries-${datasetSuffix}`;
-    const datasetsClient = new datasets.Service();
-    const client = new starred.Service();
+    const datasetsClient = new datasets.Service(url, token, orgId);
+    const client = new starred.Service(url, token, orgId);
 
     let dataset: datasets.Dataset;
     let query: starred.StarredQuery;

--- a/tests/integration/teams.test.ts
+++ b/tests/integration/teams.test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 
-import { teams } from '../../lib/teams';
+import { CloudURL, teams } from '../../lib';
+
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('TeamsService', () => {
-    const client = new teams.Service();
+    const client = new teams.Service(url, token, orgId);
 
     let team: teams.Team;
 

--- a/tests/integration/tokens.test.ts
+++ b/tests/integration/tokens.test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 
-import { tokens } from '../../lib/tokens';
+import { CloudURL, tokens } from '../../lib';
+
+const url = process.env.AXIOM_URL || CloudURL;
+const axiomToken = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('IngestTokensService', () => {
-    const client = new tokens.IngestService();
+    const client = new tokens.IngestService(url, axiomToken, orgId);
 
     let token: tokens.Token;
 
@@ -65,7 +69,7 @@ describe('IngestTokensService', () => {
 });
 
 describe('PersonalTokensService', () => {
-    const client = new tokens.PersonalService();
+    const client = new tokens.PersonalService(url, axiomToken, orgId);
 
     let token: tokens.Token;
 

--- a/tests/integration/users.test.ts
+++ b/tests/integration/users.test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 
-import { users } from '../../lib/users';
+import { CloudURL, users } from '../../lib';
+
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('UsersService', () => {
-    const client = new users.Service();
+    const client = new users.Service(url, token, orgId);
 
     let user: users.User;
 

--- a/tests/integration/version.test.ts
+++ b/tests/integration/version.test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 
-import { version } from '../../lib/version';
+import { CloudURL, version } from '../../lib';
+
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('VersionService', () => {
-    const client = new version.Service();
+    const client = new version.Service(url, token, orgId);
 
     describe('get', () => {
         it('should get a version', async () => {

--- a/tests/integration/vfields.test.ts
+++ b/tests/integration/vfields.test.ts
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 
-import { datasets } from '../../lib/datasets';
-import { vfields } from '../../lib/vfields';
+import { CloudURL, datasets, vfields } from '../../lib';
 
 const datasetSuffix = process.env.AXIOM_DATASET_SUFFIX || 'local';
+const url = process.env.AXIOM_URL || CloudURL;
+const token = process.env.AXIOM_TOKEN!;
+const orgId = process.env.AXIOM_ORG_ID;
 
 describe('VirtualFieldsService', () => {
     const datasetName = `test-axiom-node-monitors-${datasetSuffix}`;
-    const datasetsClient = new datasets.Service();
-    const client = new vfields.Service();
+    const datasetsClient = new datasets.Service(url, token, orgId);
+    const client = new vfields.Service(url, token, orgId);
 
     let dataset: datasets.Dataset;
     let vfield: vfields.VirtualField;

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import Client from '../../lib/client';
 
 describe('Client', () => {
-    const client = new Client();
+    const client = new Client('http://axiom-node.dev.local', 'foo-bar');
     expect(client).not.equal('undefined');
 
     it('Services', () => {

--- a/tests/unit/datasets.test.ts
+++ b/tests/unit/datasets.test.ts
@@ -5,7 +5,7 @@ import { datasets } from '../../lib/datasets';
 import { starred } from '../../lib/starred';
 
 describe('DatasetsService', () => {
-    const client = new datasets.Service('http://axiom-node.dev.local');
+    const client = new datasets.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const stats = {

--- a/tests/unit/monitors.test.ts
+++ b/tests/unit/monitors.test.ts
@@ -4,7 +4,7 @@ import nock from 'nock';
 import { monitors } from '../../lib/monitors';
 
 describe('MonitorsService', () => {
-    const client = new monitors.Service('http://axiom-node.dev.local');
+    const client = new monitors.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const monitors = [

--- a/tests/unit/notifiers.test.ts
+++ b/tests/unit/notifiers.test.ts
@@ -4,7 +4,7 @@ import nock from 'nock';
 import { notifiers } from '../../lib/notifiers';
 
 describe('NotifiersService', () => {
-    const client = new notifiers.Service('http://axiom-node.dev.local');
+    const client = new notifiers.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const notifiers = [

--- a/tests/unit/starred.test.ts
+++ b/tests/unit/starred.test.ts
@@ -5,7 +5,7 @@ import { CloudURL } from '../../lib';
 import { starred } from '../../lib/starred';
 
 describe('StarredQueriesService', () => {
-    const client = new starred.Service('http://axiom-node.dev.local');
+    const client = new starred.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const starred = [

--- a/tests/unit/teams.test.ts
+++ b/tests/unit/teams.test.ts
@@ -5,7 +5,7 @@ import { CloudURL } from '../../lib';
 import { teams } from '../../lib/teams';
 
 describe('TeamsService', () => {
-    const client = new teams.Service('http://axiom-node.dev.local');
+    const client = new teams.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const teams = [

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -10,7 +10,7 @@ import { tokens } from '../../lib/tokens';
 // implementation works against both endpoints.
 
 describe('TokensService', () => {
-    const client = new tokens.PersonalService('http://axiom-node.dev.local');
+    const client = new tokens.PersonalService('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const tokens = [

--- a/tests/unit/users.test.ts
+++ b/tests/unit/users.test.ts
@@ -5,7 +5,7 @@ import { CloudURL } from '../../lib';
 import { users } from '../../lib/users';
 
 describe('UsersService', () => {
-    const client = new users.Service('http://axiom-node.dev.local');
+    const client = new users.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const currentUser = {

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -5,7 +5,7 @@ import { CloudURL } from '../../lib';
 import { version } from '../../lib/version';
 
 describe('VersionsService', () => {
-    const client = new version.Service('http://axiom-node.dev.local');
+    const client = new version.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const response = {

--- a/tests/unit/vfields.test.ts
+++ b/tests/unit/vfields.test.ts
@@ -5,7 +5,7 @@ import { CloudURL } from '../../lib';
 import { vfields } from '../../lib/vfields';
 
 describe('VirtualFieldsService', () => {
-    const client = new vfields.Service('http://axiom-node.dev.local');
+    const client = new vfields.Service('http://axiom-node.dev.local', 'foo-bar');
 
     beforeEach(() => {
         const vfields = [


### PR DESCRIPTION
In my opinion a library should be explicit and not default to these
automagically.

This also removes the TOC from the README as GitHub does that
automatically now and it's not that long.
