### PR TITLE
Support apl monitors in axiom node

### DIFF
--- a/lib/datasets.ts
+++ b/lib/datasets.ts
@@ -259,7 +259,7 @@ export namespace datasets {
         priority: string;
     }
 
-    interface APLQuery {
+    export interface APLQuery {
         apl: string;
         startTime?: string;
         endTime?: string;

--- a/lib/monitors.ts
+++ b/lib/monitors.ts
@@ -10,7 +10,8 @@ export namespace monitors {
         description?: string;
         dataset: string;
         disabledUntil?: string;
-        query: datasets.Query;
+        aplQuery: boolean;
+        query: datasets.Query | datasets.APLQuery;
         threshold?: number;
         comparison: Comparison;
         noDataCloseWaitMinutes?: number;

--- a/tests/integration/monitors.test.ts
+++ b/tests/integration/monitors.test.ts
@@ -11,6 +11,7 @@ describe('MonitorsService', () => {
     const client = new monitors.Service();
 
     let monitor: monitors.Monitor;
+    let aplMonitor: monitors.Monitor;
 
     before(async () => {
         const dataset = await datasetsClient.create({
@@ -23,6 +24,7 @@ describe('MonitorsService', () => {
             description: 'A test monitor',
             dataset: dataset.name,
             comparison: monitors.Comparison.AboveOrEqual,
+            aplQuery: false,
             query: {
                 startTime: '2018-01-01T00:00:00.000Z',
                 endTime: '2028-01-01T00:00:00.000Z',
@@ -31,10 +33,24 @@ describe('MonitorsService', () => {
             frequencyMinutes: 1,
             durationMinutes: 5,
         });
+
+        aplMonitor = await client.create({
+            name: 'Test APL Monitor',
+            description: 'A test APL monitor',
+            dataset: dataset.name,
+            comparison: monitors.Comparison.AboveOrEqual,
+            aplQuery: true,
+            query: {
+                apl: `['${dataset.name}'] | count`
+            },
+            frequencyMinutes: 1,
+            durationMinutes: 5,
+        });
     });
 
     after(async () => {
         await client.delete(monitor.id!);
+        await client.delete(aplMonitor.id!);
 
         await datasetsClient.delete(datasetName);
     });
@@ -46,6 +62,7 @@ describe('MonitorsService', () => {
                 description: 'A very good test monitor',
                 dataset: datasetName,
                 comparison: monitors.Comparison.AboveOrEqual,
+                aplQuery: false,
                 query: {
                     startTime: '2018-01-01T00:00:00.000Z',
                     endTime: '2028-01-01T00:00:00.000Z',

--- a/tests/unit/monitors.test.ts
+++ b/tests/unit/monitors.test.ts
@@ -7,12 +7,13 @@ describe('MonitorsService', () => {
     const client = new monitors.Service('http://axiom-node.dev.local');
 
     beforeEach(() => {
-        const monitors = [
+        const mockMonitors: monitors.Monitor[] = [
             {
                 id: 'nGxDh3TGuidQJgJW3s',
                 name: 'Test',
                 description: 'A test monitor',
                 disabledUntil: '0001-01-01T00:00:00Z',
+                aplQuery: false,
                 query: {
                     startTime: '2020-11-30T14:28:29Z',
                     endTime: '2020-11-30T14:33:29Z',
@@ -20,7 +21,7 @@ describe('MonitorsService', () => {
                 },
                 dataset: 'test',
                 threshold: 1000,
-                comparison: 'AboveOrEqual',
+                comparison: monitors.Comparison.AboveOrEqual,
                 frequencyMinutes: 1,
                 durationMinutes: 5,
                 lastCheckTime: '2020-11-30T14:37:13Z',
@@ -30,14 +31,15 @@ describe('MonitorsService', () => {
                 name: 'Test',
                 description: 'A test monitor',
                 disabledUntil: '0001-01-01T00:00:00Z',
+                aplQuery: true,
                 query: {
                     startTime: '0001-01-01T00:00:00Z',
                     endTime: '0001-01-01T00:00:00Z',
-                    resolution: '',
+                    apl: 'test | count'
                 },
                 dataset: 'test',
                 threshold: 0,
-                comparison: 'Below',
+                comparison: monitors.Comparison.Below,
                 frequencyMinutes: 0,
                 durationMinutes: 0,
                 lastCheckTime: '0001-01-01T00:00:00Z',
@@ -46,10 +48,10 @@ describe('MonitorsService', () => {
 
         const scope = nock('http://axiom-node.dev.local');
 
-        scope.get('/api/v1/monitors').reply(200, monitors);
-        scope.get('/api/v1/monitors/nGxDh3TGuidQJgJW3s').reply(200, monitors[0]);
-        scope.post('/api/v1/monitors').reply(200, monitors[1]);
-        scope.put('/api/v1/monitors/lrR66wmzYm9NKtq0rz').reply(200, monitors[1]);
+        scope.get('/api/v1/monitors').reply(200, mockMonitors);
+        scope.get('/api/v1/monitors/nGxDh3TGuidQJgJW3s').reply(200, mockMonitors[0]);
+        scope.post('/api/v1/monitors').reply(200, mockMonitors[1]);
+        scope.put('/api/v1/monitors/lrR66wmzYm9NKtq0rz').reply(200, mockMonitors[1]);
         scope.delete('/api/v1/monitors/lrR66wmzYm9NKtq0rz').reply(204);
     });
 
@@ -74,6 +76,7 @@ describe('MonitorsService', () => {
             description: 'A test monitor',
             dataset: 'test',
             comparison: monitors.Comparison.Below,
+            aplQuery: false,
             query: {
                 startTime: '2018-01-01T00:00:00.000Z',
                 endTime: '2028-01-01T00:00:00.000Z',
@@ -98,6 +101,7 @@ describe('MonitorsService', () => {
             description: 'A test monitor',
             dataset: 'test',
             comparison: monitors.Comparison.Below,
+            aplQuery: false,
             query: {
                 startTime: '2018-01-01T00:00:00.000Z',
                 endTime: '2028-01-01T00:00:00.000Z',


### PR DESCRIPTION
A monitor can be either a structured query or an APL query, this PR adds support for the latter.