### PR TITLE
set type of query in history handlers

### DIFF
--- a/lib/datasets.ts
+++ b/lib/datasets.ts
@@ -70,7 +70,7 @@ export namespace datasets {
         id: string;
         dataset: string;
         kind: starred.QueryKind;
-        // query: QueryRequest; //FIXME(lukasmalkmus): Add QueryRequest type
+        query: datasets.Query | datasets.APLQuery
         who: string;
         created: string;
     }
@@ -259,7 +259,7 @@ export namespace datasets {
         priority: string;
     }
 
-    interface APLQuery {
+    export interface APLQuery {
         apl: string;
         startTime?: string;
         endTime?: string;

--- a/lib/starred.ts
+++ b/lib/starred.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios';
+import { datasets } from 'datasets';
 
 import HTTPClient from './httpClient';
 import GlobalListOptions from './options';
@@ -9,7 +10,7 @@ export namespace starred {
         name: string;
         dataset: string;
         kind: QueryKind;
-        // query: QueryRequest; //FIXME(lukasmalkmus): Add QueryRequest type
+        query: datasets.Query | datasets.APLQuery
         who?: string;
         metadata?: { [key: string]: string };
         created?: string;

--- a/tests/integration/starred.test.ts
+++ b/tests/integration/starred.test.ts
@@ -23,6 +23,9 @@ describe('StarredQueriesService', () => {
             name: 'Test Query',
             kind: starred.QueryKind.Stream,
             dataset: dataset.id.toString(),
+            query: {
+                apl: "['" + datasetName + "']"
+            }
         });
     });
 
@@ -38,6 +41,9 @@ describe('StarredQueriesService', () => {
                 name: 'Updated Test Query',
                 kind: starred.QueryKind.Stream,
                 dataset: dataset.id.toString(),
+                query: {
+                    apl: "['" + datasetName + "']"
+                }
             });
 
             expect(updatedQuery.name).to.equal('Updated Test Query');
@@ -46,21 +52,21 @@ describe('StarredQueriesService', () => {
         });
     });
 
-    // describe('get', () => {
-    //     it('should get a query', async () => {
-    //         const fetchedQuery = await client.get(query.id!);
+    describe('get', () => {
+        it('should get a query', async () => {
+            const fetchedQuery = await client.get(query.id!);
 
-    //         expect(fetchedQuery.name).to.equal(query.name);
-    //     });
-    // });
+            expect(fetchedQuery.name).to.equal(query.name);
+        });
+    });
 
-    // describe('list', () => {
-    //     it('should list starred', async () => {
-    //         const starred = await client.list({
-    //             kind: QueryKind.Analytics,
-    //         });
+    describe('list', () => {
+        it('should list starred', async () => {
+            const starredList = await client.list({
+                kind: starred.QueryKind.Analytics,
+            });
 
-    //         expect(starred.length).to.be.greaterThan(0);
-    //     });
-    // });
+            expect(starredList.length).to.be.greaterThan(0);
+        });
+    });
 });

--- a/tests/integration/starred.test.ts
+++ b/tests/integration/starred.test.ts
@@ -21,7 +21,7 @@ describe('StarredQueriesService', () => {
 
         query = await client.create({
             name: 'Test Query',
-            kind: starred.QueryKind.Stream,
+            kind: starred.QueryKind.Analytics,
             dataset: dataset.id.toString(),
             query: {
                 apl: "['" + datasetName + "']"
@@ -39,7 +39,7 @@ describe('StarredQueriesService', () => {
         it('should update a query', async () => {
             const updatedQuery = await client.update(query.id!, {
                 name: 'Updated Test Query',
-                kind: starred.QueryKind.Stream,
+                kind: starred.QueryKind.Analytics,
                 dataset: dataset.id.toString(),
                 query: {
                     apl: "['" + datasetName + "']"
@@ -63,10 +63,13 @@ describe('StarredQueriesService', () => {
     describe('list', () => {
         it('should list starred', async () => {
             const starredList = await client.list({
+                dataset: datasetName,
                 kind: starred.QueryKind.Analytics,
+                who: starred.OwnerKind.User,
             });
 
             expect(starredList.length).to.be.greaterThan(0);
+            expect(starredList[0].id).eq(query.id);
         });
     });
 });

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -90,7 +90,7 @@ describe('Client', () => {
         }
     });
 
-    it.only('shortcircuit ingest rate limit', async () => {
+    it('shortcircuit ingest rate limit', async () => {
         const scope = nock('http://axiom-node-retries.dev.local');
         const resetTime = new Date();
         resetTime.setHours(resetTime.getHours() + 1);

--- a/tests/unit/starred.test.ts
+++ b/tests/unit/starred.test.ts
@@ -83,11 +83,12 @@ describe('StarredQueriesService', () => {
             kind: starred.QueryKind.Analytics,
             dataset: 'test',
             name: 'Everything',
-            // query: {
-            //     startTime: '2020-11-24T16:23:15.000Z',
-            //     endTime: '2020-11-24T16:53:30.000Z',
-            //     limit: 1000,
-            // },
+            query: {
+                startTime: '2020-11-24T16:23:15.000Z',
+                endTime: '2020-11-24T16:53:30.000Z',
+                limit: 1000,
+                resolution: 'auto'
+            },
             metadata: {
                 quickRange: '7d',
             },
@@ -105,11 +106,12 @@ describe('StarredQueriesService', () => {
             kind: starred.QueryKind.Analytics,
             dataset: 'test',
             name: 'Everything',
-            // query: {
-            //     startTime: '2020-11-24T16:23:15.000Z',
-            //     endTime: '2020-11-24T16:53:30.000Z',
-            //     limit: 1000,
-            // },
+            query: {
+                startTime: '2020-11-24T16:23:15.000Z',
+                endTime: '2020-11-24T16:53:30.000Z',
+                limit: 1000,
+                resolution: 'auto'
+            },
             metadata: {
                 quickRange: '7d',
             },


### PR DESCRIPTION
This PR aims to set the query type of History and Starred to `datasets.Query | datasets.APLQuery`. It fixes the and uncomment the tests for those two as well.

@lukasmalkmus would this be a proper solution to this comment?

```
// query: QueryRequest; //FIXME(lukasmalkmus): Add QueryRequest type
```