### PR TITLE
Fix AplQuery, tests, format files

### DIFF
--- a/lib/datasets.ts
+++ b/lib/datasets.ts
@@ -175,6 +175,15 @@ export namespace datasets {
         status: Status;
     }
 
+    export interface AplQueryResult {
+        request: Query;
+
+        // Copied from QueryResult
+        buckets: Timeseries;
+        matches?: Array<Entry>;
+        status: Status;
+    }
+
     export interface Timeseries {
         series?: Array<Interval>;
         totals?: Array<EntryGroup>;
@@ -333,10 +342,10 @@ export namespace datasets {
                     return response.data;
                 });
 
-        aplQuery = (apl: string, options?: APLQueryOptions): Promise<QueryResult> => {
+        aplQuery = (apl: string, options?: APLQueryOptions): Promise<AplQueryResult> => {
             const req: APLQuery = { apl: apl, startTime: options?.startTime, endTime: options?.endTime };
             return this.client
-                .post<QueryResult>(this.localPath + '/_apl', req, {
+                .post<AplQueryResult>(this.localPath + '/_apl', req, {
                     params: {
                         'streaming-duration': options?.streamingDuration,
                         nocache: options?.noCache,

--- a/lib/datasets.ts
+++ b/lib/datasets.ts
@@ -117,7 +117,7 @@ export namespace datasets {
         MakeSet = 'makeset',
         MakeSetIf = 'makesetif',
         CountIf = 'countif',
-        CountDistinctIf = 'distinctif'
+        CountDistinctIf = 'distinctif',
     }
 
     export interface Filter {
@@ -316,9 +316,9 @@ export namespace datasets {
             options?: IngestOptions,
         ): Promise<IngestStatus> => {
             const array = Array.isArray(events) ? events : [events];
-            const json = array.map(v => JSON.stringify(v)).join("\n");
+            const json = array.map((v) => JSON.stringify(v)).join('\n');
             const encoded = await promisify(gzip)(json);
-            return this.ingestBuffer(id, encoded, ContentType.NDJSON, ContentEncoding.GZIP, options)
+            return this.ingestBuffer(id, encoded, ContentType.NDJSON, ContentEncoding.GZIP, options);
         };
 
         query = (id: string, query: Query, options?: QueryOptions): Promise<QueryResult> =>

--- a/lib/httpClient.ts
+++ b/lib/httpClient.ts
@@ -56,17 +56,20 @@ export default abstract class HTTPClient {
                     return Promise.reject(error);
                 }
 
-                const limit = parseLimitFromResponse(error.response);
-                const key = limitKey(limit.type, limit.scope);
-                this.limits[key] = limit;
+                // Some errors don't have a response (i.e. when unit-testing)
+                if (error.response) {
+                    const limit = parseLimitFromResponse(error.response);
+                    const key = limitKey(limit.type, limit.scope);
+                    this.limits[key] = limit;
 
-                if (error.response.status == 429) {
-                    return Promise.reject(new AxiomTooManyRequestsError(limit, error.response));
-                }
+                    if (error.response.status == 429) {
+                        return Promise.reject(new AxiomTooManyRequestsError(limit, error.response));
+                    }
 
-                const message = error.response.data.message;
-                if (message) {
-                    return Promise.reject(new Error(message));
+                    const message = error.response.data.message;
+                    if (message) {
+                        return Promise.reject(new Error(message));
+                    }
                 }
 
                 return Promise.reject(error);

--- a/lib/httpClient.ts
+++ b/lib/httpClient.ts
@@ -8,7 +8,7 @@ export const CloudURL = 'https://cloud.axiom.co';
 
 export default abstract class HTTPClient {
     protected readonly client: AxiosInstance;
-    limits: {[key: string]: Limit} = {};
+    limits: { [key: string]: Limit } = {};
 
     constructor(
         basePath: string = process.env.AXIOM_URL || CloudURL,
@@ -127,16 +127,15 @@ export class AxiomTooManyRequestsError extends Error {
         }
     }
 
-    timeUntilReset(){
+    timeUntilReset() {
         const total = this.limit.reset.getTime() - new Date().getTime();
-        const seconds = Math.floor( (total/1000) % 60 );
-        const minutes = Math.floor( (total/1000/60) % 60 );
-      
+        const seconds = Math.floor((total / 1000) % 60);
+        const minutes = Math.floor((total / 1000 / 60) % 60);
+
         return {
-          total,
-          minutes,
-          seconds
+            total,
+            minutes,
+            seconds,
         };
-      }
-      
+    }
 }

--- a/lib/limit.ts
+++ b/lib/limit.ts
@@ -1,29 +1,29 @@
-import { AxiosResponse } from "axios";
+import { AxiosResponse } from 'axios';
 
-export const headerRateScope     = "X-RateLimit-Scope"
+export const headerRateScope = 'X-RateLimit-Scope';
 
-export const headerAPILimit     = "X-RateLimit-Limit"
-export const headerAPIRateRemaining = "X-RateLimit-Remaining"
-export const headerAPIRateReset     = "X-RateLimit-Reset"
+export const headerAPILimit = 'X-RateLimit-Limit';
+export const headerAPIRateRemaining = 'X-RateLimit-Remaining';
+export const headerAPIRateReset = 'X-RateLimit-Reset';
 
-export const headerQueryLimit     = "X-QueryLimit-Limit"
-export const headerQueryRemaining = "X-QueryLimit-Remaining"
-export const headerQueryReset     = "X-QueryLimit-Reset"
+export const headerQueryLimit = 'X-QueryLimit-Limit';
+export const headerQueryRemaining = 'X-QueryLimit-Remaining';
+export const headerQueryReset = 'X-QueryLimit-Reset';
 
-export const headerIngestLimit     = "X-IngestLimit-Limit"
-export const headerIngestRemaining = "X-IngestLimit-Remaining"
-export const headerIngestReset     = "X-IngestLimit-Reset"
+export const headerIngestLimit = 'X-IngestLimit-Limit';
+export const headerIngestRemaining = 'X-IngestLimit-Remaining';
+export const headerIngestReset = 'X-IngestLimit-Reset';
 
 export enum LimitScope {
-    unknown = "unknown",
-    user = "user",
-    organization = "organization",
-    anonymous = "anonymous",
+    unknown = 'unknown',
+    user = 'user',
+    organization = 'organization',
+    anonymous = 'anonymous',
 }
 export enum LimitType {
-    api = "api",
-    query = "query",
-    ingest = "ingest",
+    api = 'api',
+    query = 'query',
+    ingest = 'ingest',
 }
 
 export class Limit {
@@ -40,16 +40,22 @@ export class Limit {
 export function parseLimitFromResponse(response: AxiosResponse): Limit {
     let limit: Limit;
 
-    if (response.config.url?.endsWith("/ingest")) {
-		limit = parseLimitFromHeaders(response, "", headerIngestLimit, headerIngestRemaining, headerIngestReset)
-		limit.type = LimitType.ingest
-	} else if (response.config.url?.endsWith("/query") || response.config.url?.endsWith("/_apl")) {
-		limit = parseLimitFromHeaders(response, "", headerQueryLimit, headerQueryRemaining, headerQueryReset)
-		limit.type = LimitType.query
-	} else {
-		limit = parseLimitFromHeaders(response, headerRateScope, headerAPILimit, headerAPIRateRemaining, headerAPIRateReset)
-		limit.type = LimitType.api
-	}
+    if (response.config.url?.endsWith('/ingest')) {
+        limit = parseLimitFromHeaders(response, '', headerIngestLimit, headerIngestRemaining, headerIngestReset);
+        limit.type = LimitType.ingest;
+    } else if (response.config.url?.endsWith('/query') || response.config.url?.endsWith('/_apl')) {
+        limit = parseLimitFromHeaders(response, '', headerQueryLimit, headerQueryRemaining, headerQueryReset);
+        limit.type = LimitType.query;
+    } else {
+        limit = parseLimitFromHeaders(
+            response,
+            headerRateScope,
+            headerAPILimit,
+            headerAPIRateRemaining,
+            headerAPIRateReset,
+        );
+        limit.type = LimitType.api;
+    }
 
     return limit;
 }
@@ -57,30 +63,35 @@ export function parseLimitFromResponse(response: AxiosResponse): Limit {
 export const limitKey = (type: LimitType, scope: LimitScope): string => `${type}:${scope}`;
 
 // parseLimitFromHeaders parses the named headers from a `*http.Response`.
-function parseLimitFromHeaders(response: AxiosResponse, headerScope: string, headerLimit: string, headerRemaining: string, headerReset: string): Limit {
-	let limit: Limit = new Limit();
+function parseLimitFromHeaders(
+    response: AxiosResponse,
+    headerScope: string,
+    headerLimit: string,
+    headerRemaining: string,
+    headerReset: string,
+): Limit {
+    let limit: Limit = new Limit();
 
     const scope: string = response.headers[headerScope.toLowerCase()] || LimitScope.unknown;
     limit.scope = LimitScope[scope as keyof typeof LimitScope];
-    
+
     const limitValue = response.headers[headerLimit.toLowerCase()];
     const limitValueNumber = parseInt(limitValue, 10);
     if (!isNaN(limitValueNumber)) {
-        limit.value = limitValueNumber
+        limit.value = limitValueNumber;
     }
-    
+
     const remainingValue = response.headers[headerRemaining.toLowerCase()];
     const remainingValueNumber = parseInt(remainingValue, 10);
     if (!isNaN(remainingValueNumber)) {
-        limit.remaining = remainingValueNumber
+        limit.remaining = remainingValueNumber;
     }
-
 
     const resetValue = response.headers[headerReset.toLowerCase()];
     const resetValueInt = parseInt(resetValue, 10);
-    if(!isNaN(resetValueInt)) {
+    if (!isNaN(resetValueInt)) {
         limit.reset = new Date(resetValueInt * 1000);
     }
 
-	return limit
+    return limit;
 }

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,13 +1,11 @@
 import HTTPClient from './httpClient';
 
 export namespace users {
-
     export interface User {
         id: string;
         name: string;
         emails: Array<string>;
     }
-
 
     export class Service extends HTTPClient {
         private readonly localPath = '/api/v1/users';

--- a/tests/unit/datasets.test.ts
+++ b/tests/unit/datasets.test.ts
@@ -101,8 +101,8 @@ describe('DatasetsService', () => {
         });
         scope.post('/api/v1/datasets/test/query').reply(200, queryResult);
         scope.post('/api/v1/datasets/test/query?streaming-duration=1m&nocache=true').reply(200, queryResult);
-        scope.post('/api/v1/datasets/_apl').reply(200, queryResult);
-        scope.post('/api/v1/datasets/_apl?streaming-duration=1m&nocache=true').reply(200, queryResult);
+        scope.post('/api/v1/datasets/_apl?format=legacy').reply(200, queryResult);
+        scope.post('/api/v1/datasets/_apl?streaming-duration=1m&nocache=true&format=legacy').reply(200, queryResult);
     });
 
     it('List', async () => {
@@ -167,48 +167,44 @@ describe('DatasetsService', () => {
     });
 
     it('Query', async () => {
-        it('works without options', async () => {
-            const query = {
-                startTime: '2020-11-26T11:18:00Z',
-                endTime: '2020-11-17T11:18:00Z',
-                resolution: 'auto',
-            };
-            const response = await client.query('test', query);
-            expect(response).not.equal('undefined');
-            expect(response.matches).length(2);
-        });
+        // works without options
+        let query = {
+            startTime: '2020-11-26T11:18:00Z',
+            endTime: '2020-11-17T11:18:00Z',
+            resolution: 'auto',
+        };
+        let response = await client.query('test', query);
+        expect(response).not.equal('undefined');
+        expect(response.matches).length(2);
 
-        it('works with options', async () => {
-            const query = {
-                startTime: '2020-11-26T11:18:00Z',
-                endTime: '2020-11-17T11:18:00Z',
-                resolution: 'auto',
-            };
-            const options = {
-                streamingDuration: '1m',
-                noCache: true,
-            };
-            const response = await client.query('test', query, options);
-            expect(response).not.equal('undefined');
-            expect(response.matches).length(2);
-        });
+        // works with options
+        query = {
+            startTime: '2020-11-26T11:18:00Z',
+            endTime: '2020-11-17T11:18:00Z',
+            resolution: 'auto',
+        };
+        const options = {
+            streamingDuration: '1m',
+            noCache: true,
+        };
+        response = await client.query('test', query, options);
+        expect(response).not.equal('undefined');
+        expect(response.matches).length(2);
     });
 
     it('APL Query', async () => {
-        it('works without options', async () => {
-            const response = await client.aplQuery("['test'] | where response == 304");
-            expect(response).not.equal('undefined');
-            expect(response.matches).length(2);
-        });
+        // works without options
+        let response = await client.aplQuery("['test'] | where response == 304");
+        expect(response).not.equal('undefined');
+        expect(response.matches).length(2);
 
-        it('works with options', async () => {
-            const options = {
-                streamingDuration: '1m',
-                noCache: true,
-            };
-            const response = await client.aplQuery("['test'] | where response == 304", options);
-            expect(response).not.equal('undefined');
-            expect(response.matches).length(2);
-        });
+        // works with options
+        const options = {
+            streamingDuration: '1m',
+            noCache: true,
+        };
+        response = await client.aplQuery("['test'] | where response == 304", options);
+        expect(response).not.equal('undefined');
+        expect(response.matches).length(2);
     });
 });

--- a/tests/unit/datasets.test.ts
+++ b/tests/unit/datasets.test.ts
@@ -83,6 +83,15 @@ describe('DatasetsService', () => {
             },
         };
 
+        const aplQueryResult = {
+            request: {
+                startTime: '2020-11-19T11:06:31.569475746Z',
+                endTime: '2020-11-27T12:06:38.966791794Z',
+                resolution: "auto"
+            },
+            ...queryResult,
+        }
+
         const scope = nock('http://axiom-node.dev.local');
 
         scope.get('/api/v1/datasets').reply(200, datasets);
@@ -101,8 +110,8 @@ describe('DatasetsService', () => {
         });
         scope.post('/api/v1/datasets/test/query').reply(200, queryResult);
         scope.post('/api/v1/datasets/test/query?streaming-duration=1m&nocache=true').reply(200, queryResult);
-        scope.post('/api/v1/datasets/_apl?format=legacy').reply(200, queryResult);
-        scope.post('/api/v1/datasets/_apl?streaming-duration=1m&nocache=true&format=legacy').reply(200, queryResult);
+        scope.post('/api/v1/datasets/_apl?format=legacy').reply(200, aplQueryResult);
+        scope.post('/api/v1/datasets/_apl?streaming-duration=1m&nocache=true&format=legacy').reply(200, aplQueryResult);
     });
 
     it('List', async () => {


### PR DESCRIPTION
This formats all files, fixes an issue with tests (you can't nest `it`) and adds a `AplQueryResult` type which contains the request.

Unknown aggregations are handled gracefully in typescript.