### PR TITLE
Update readme and client constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ all that are supported.
 | `AXIOM_ORG_ID`       | Your Axiom org id, necessary for personal tokens                                         |
 | `AXIOM_URL`          | If you self-host Axiom, set this to your deployment url                                  |
 
-You can programatically override these by passing an options object to the 
+You can programmatically override these by passing an options object to the 
 `Client` constructor, here's an example with all values set:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const client = new Client({
 ## Contributing
 
 The main aim of this repository is to continue developing and advancing
-axoim-node, making it faster and simpler to use. Kindly check our
+axiom-node, making it faster and simpler to use. Kindly check our
 [contributing guide](https://github.com/axiomhq/axiom-node/blob/main/Contributing.md)
 on how to propose bugfixes and improvements, and submitting pull requests to the
 project

--- a/README.md
+++ b/README.md
@@ -1,95 +1,66 @@
-# Axiom Node
-
-[![Workflow][workflow_badge]][workflow]
-[![Latest Release][release_badge]][release]
-[![License][license_badge]][license]
+# axiom-node [![Workflow][workflow_badge]][workflow] [![Latest Release][release_badge]][release] [![License][license_badge]][license]
 
 ![Alt](https://repobeats.axiom.co/api/embed/40b1a942132e3f515d5374bde5e47fb0750eb411.svg "Repobeats analytics image")
 
----
+The Node SDK for [Axiom](https://www.axiom.co/).
 
-## Table of Contents
+## Quickstart
 
-1. [Introduction](#introduction)
-1. [Installation](#installation)
-1. [Authentication](#authentication)
-1. [Usage](#usage)
-1. [Documentation](#documentation)
-1. [Contributing](#contributing)
-1. [License](#license)
-
-## Introduction
-
-Axiom Node is a NodeJS package for accessing the [Axiom](https://www.axiom.co/)
-API.
-
-## Installation 
-
-### Install using `npm`
+Install the package:
 
 ```shell
-npm i @axiomhq/axiom-node
+npm install @axiomhq/axiom-node
 ```
 
-### Install from source
-
-```shell
-git clone https://github.com/axiomhq/axiom-node
-cd axiom-node
-npm install
-```
-
-## Authentication
-
-The client is initialized with the url of the deployment and an access token
-when using Axiom Selfhost or an access token and the users organization id when
-using Axiom Cloud.
-
-The access token can be a personal token retrieved from the users profile page
-or an ingest token retrieved from the settings of the Axiom deployment.
-
-The personal access token grants access to all resources available to the user
-on his behalf.
-
-The ingest token just allows ingestion into the datasets the token is configured
-for.
-
-## Usage
+Then use it like this:
 
 ```ts
-// Export `AXIOM_TOKEN` and `AXIOM_ORG_ID` for Axiom Cloud
-// Export `AXIOM_URL` and `AXIOM_TOKEN` for Axiom Selfhost
-
 import Client from '@axiomhq/axiom-node';
 
+// Construct a client from environment variables
+// Export an API token in `AXIOM_TOKEN` for this to work
 const client = new Client();
 
-// ...
+// Ingest two events
+await client.datasets.ingestEvents('my-application', [
+  { 'method': 'GET', path: '/' },
+  { 'method': 'POST', path: '/login' }
+]);
+
+// Query the dataset
+const res = await client.datasets.aplQuery(`['my-application'] | summarize count() by bin_auto(_time)`);
+const count = res.buckets.totals![0].aggregations![0].value;
+console.log(`We have a count of ${count}`);
 ```
 
 For more sample code snippets, head over to the [examples](examples) directory.
 
-## Documentation
+## Advanced configuration
 
-You can find the Axiom and Axiom node documentation
-[on the docs website.](https://docs.axiom.co/)
+The quickstart example above creates a client by environment variables, here's 
+all that are supported.
 
-The documentation is divided into several sections:
+| Environment variable | Description                                                                              |
+|----------------------|------------------------------------------------------------------------------------------|
+| `AXIOM_TOKEN`        | An Axiom API or personal token. If it's a personal token you'll also need `AXIOM_ORG_ID` |
+| `AXIOM_ORG_ID`       | Your Axiom org id, necessary for personal tokens                                         |
+| `AXIOM_URL`          | If you self-host Axiom, set this to your deployment url                                  |
 
-- [Overview of Axiom](https://docs.axiom.co/usage/getting-started/)
-- **Installing Axiom:**
-  - [Axiom Cloud](https://docs.axiom.co/install/cloud/)
-  - [Desktop Demo](https://docs.axiom.co/install/demo/)
-  - [Runing Axiom on Kubernetes](https://docs.axiom.co/install/kubernetes/)
-- [Axiom API](https://docs.axiom.co/reference/api/)
-- [Axiom CLI](https://github.com/axiomhq/cli)
-- [Getting Support](https://www.axiom.co/support/)
-- [Data Shippers we support](https://docs.axiom.co/data-shippers/elastic-beats/)
+You can programatically override these by passing an options object to the 
+`Client` constructor, here's an example with all values set:
+
+```ts
+const client = new Client({
+  token: "xaat-xxxx",
+  orgId: "my-org",
+  url: "http://my-axiom.example.org"
+});
+```
 
 ## Contributing
 
-The main aim of this repository is to continue developing and advancing Axiom
-Node, making it faster and simpler to use. Kindly check our
+The main aim of this repository is to continue developing and advancing
+axoim-node, making it faster and simpler to use. Kindly check our
 [contributing guide](https://github.com/axiomhq/axiom-node/blob/main/Contributing.md)
 on how to propose bugfixes and improvements, and submitting pull requests to the
 project

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,15 +1,16 @@
 import { datasets } from './datasets';
 import { users } from './users';
 import { version } from './version';
+import { ClientOptions } from './httpClient';
 
 export default class Client {
     datasets: datasets.Service;
     users: users.Service;
     version: version.Service;
 
-    constructor(basePath?: string, accessToken?: string, orgID?: string) {
-        this.datasets = new datasets.Service(basePath, accessToken, orgID);
-        this.users = new users.Service(basePath, accessToken, orgID);
-        this.version = new version.Service(basePath, accessToken, orgID);
+    constructor(options?: ClientOptions) {
+        this.datasets = new datasets.Service(options);
+        this.users = new users.Service(options);
+        this.version = new version.Service(options);
     }
 }

--- a/lib/datasets.ts
+++ b/lib/datasets.ts
@@ -35,8 +35,7 @@ export namespace datasets {
         hidden: boolean;
     }
 
-    export interface TrimResult {
-    }
+    export interface TrimResult {}
 
     export interface CreateRequest {
         name: string;

--- a/lib/httpClient.ts
+++ b/lib/httpClient.ts
@@ -6,25 +6,31 @@ const Version = require('../package.json').version;
 
 export const CloudURL = 'https://cloud.axiom.co';
 
+export interface ClientOptions {
+    token?: string;
+    url?: string;
+    orgId?: string;
+}
+
 export default abstract class HTTPClient {
     protected readonly client: AxiosInstance;
     limits: { [key: string]: Limit } = {};
 
-    constructor(
-        basePath: string = process.env.AXIOM_URL || CloudURL,
-        accessToken: string = process.env.AXIOM_TOKEN || '',
-        orgID: string = process.env.AXIOM_ORG_ID || '',
-    ) {
+    constructor(options: ClientOptions = {}) {
+        const token = options.token || process.env.AXIOM_TOKEN || '';
+        const url = options.url || process.env.AXIOM_URL || CloudURL;
+        const orgId = options.orgId || process.env.AXIOM_ORG_ID || '';
+
         this.client = axios.create({
-            baseURL: basePath,
+            baseURL: url,
             timeout: 30000,
         });
 
         this.client.defaults.headers.common['Accept'] = 'application/json';
         this.client.defaults.headers.common['User-Agent'] = 'axiom-node/' + Version;
-        this.client.defaults.headers.common['Authorization'] = 'Bearer ' + accessToken;
-        if (orgID) {
-            this.client.defaults.headers.common['X-Axiom-Org-Id'] = orgID;
+        this.client.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+        if (orgId) {
+            this.client.defaults.headers.common['X-Axiom-Org-Id'] = orgId;
         }
 
         // We should only retry in the case the status code is >= 500, anything below isn't worth retrying.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@axiomhq/axiom-node",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@axiomhq/axiom-node",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/axiom-node",
     "description": "TypeScript bindings for the Axiom API.",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "author": "Axiom, Inc.",
     "license": "MIT",
     "contributors": [

--- a/tests/integration/datasets.test.ts
+++ b/tests/integration/datasets.test.ts
@@ -109,13 +109,13 @@ baz`,
             const status = await client.ingestEvents(datasetName, { foo: 'bar' });
             expect(status.ingested).to.equal(1);
             expect(status.failures?.length).to.equal(0);
-        })
+        });
 
         it('works with two events', async () => {
             const status = await client.ingestEvents(datasetName, [{ foo: 'bar' }, { bar: 'baz' }]);
             expect(status.ingested).to.equal(2);
             expect(status.failures?.length).to.equal(0);
-        })
+        });
     });
 
     describe('query', () => {

--- a/tests/unit/datasets.test.ts
+++ b/tests/unit/datasets.test.ts
@@ -4,7 +4,7 @@ import nock from 'nock';
 import { datasets } from '../../lib/datasets';
 
 describe('DatasetsService', () => {
-    const client = new datasets.Service('http://axiom-node.dev.local');
+    const client = new datasets.Service({ url: 'http://axiom-node.dev.local' });
 
     beforeEach(() => {
         const datasets = [
@@ -87,10 +87,10 @@ describe('DatasetsService', () => {
             request: {
                 startTime: '2020-11-19T11:06:31.569475746Z',
                 endTime: '2020-11-27T12:06:38.966791794Z',
-                resolution: "auto"
+                resolution: 'auto',
             },
             ...queryResult,
-        }
+        };
 
         const scope = nock('http://axiom-node.dev.local');
 
@@ -99,8 +99,7 @@ describe('DatasetsService', () => {
         scope.post('/api/v1/datasets').reply(200, datasets[1]);
         scope.put('/api/v1/datasets/test1').reply(200, datasets[1]);
         scope.delete('/api/v1/datasets/test1').reply(204);
-        scope.post('/api/v1/datasets/test1/trim').reply(200, {
-        });
+        scope.post('/api/v1/datasets/test1/trim').reply(200, {});
         scope.post('/api/v1/datasets/test/ingest').reply(function (_, body, cb) {
             expect(this.req.headers).to.have.property('content-type');
             expect(body).to.deep.equal([{ foo: 'bar' }, { foo: 'baz' }]);

--- a/tests/unit/users.test.ts
+++ b/tests/unit/users.test.ts
@@ -4,7 +4,7 @@ import nock from 'nock';
 import { users } from '../../lib/users';
 
 describe('UsersService', () => {
-    const client = new users.Service('http://axiom-node.dev.local');
+    const client = new users.Service({ url: 'http://axiom-node.dev.local' });
 
     beforeEach(() => {
         const currentUser = {

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
 import nock from 'nock';
 
-import { CloudURL } from '../../lib';
 import { version } from '../../lib/version';
 
 describe('VersionsService', () => {
-    const client = new version.Service('http://axiom-node.dev.local');
+    const client = new version.Service({ url: 'http://axiom-node.dev.local' });
 
     beforeEach(() => {
         const response = {


### PR DESCRIPTION
This adds a quickstart section to the README, hopefully making it easier for people to get started without digging into the examples.

It also changes the `Client` constructor to take an options object instead of `url?, accessToken?, orgId?` which can be awkward to use. 

Since ^ is a breaking change, it's also bumping the version to 0.8.