### PR TITLE
update package.json version to 0.10.0

### DIFF
--- a/lib/datasets.ts
+++ b/lib/datasets.ts
@@ -355,5 +355,7 @@ export namespace datasets {
                     return response.data;
                 });
         };
+
+        aplQuery = (apl: string, options?: QueryOptions): Promise<QueryResult> => this.query(apl, options);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@axiomhq/axiom-node",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@axiomhq/axiom-node",
-            "version": "0.9.0",
+            "version": "0.10.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/axiom-node",
     "description": "The official NodeJS bindings for the Axiom API",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "author": "Axiom, Inc.",
     "license": "MIT",
     "contributors": [


### PR DESCRIPTION
tried to release v0.10.0 before updating package.json, this PR fixes that, a new release would be required after merging this.

@bahlo since the release has failed, I thought there is still a chance to keep `aplQuery` function. I added it in the second commit. what do you think?