### PR TITLE
Add batching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ async function main() {
 }
 ```
 
+## Sending events in batches
+
+Sending many individual events can affect deliverability. You can use built-in
+batching suport like this:
+
+```ts
+import { Client } from '@axiomhq/axiom-node';
+
+async function main() {
+    const client = new Client();
+
+    const batch = client.createBatch('my-dataset');
+    batch.ingestEvents({ foo: 'bar' });
+    batch.ingestEvents({ foo: 'bar' });
+
+    await batch.flush();
+}
+```
+
+This will send events once a second has passed or you added 1k events, whatever
+happens first.
+Make sure to `flush()` on exit to ensure all events are sent.
+
 ## Using Axiom transport for Winston
 
 You can use Winston logger to send logs to Axiom. First, install the `winston` and `@axiomhq/axiom-node` packages, then

--- a/lib/batch.ts
+++ b/lib/batch.ts
@@ -1,0 +1,56 @@
+import { IngestOptions, IngestStatus } from './client';
+
+type IngestFunction = (id: string, events: Array<object> | object, options?: IngestOptions) => Promise<IngestStatus>;
+
+export class Batch {
+    ingestFn: IngestFunction;
+    id: string;
+    options?: IngestOptions;
+
+    events: Array<object> = [];
+
+    activeFlush: Promise<IngestStatus | void> = Promise.resolve();
+    nextFlush: NodeJS.Timeout = setTimeout(() => {}, 0);
+    lastFlush: Date = new Date();
+
+    constructor(ingestFn: IngestFunction, id: string, options?: IngestOptions) {
+        this.ingestFn = ingestFn;
+        this.id = id;
+        this.options = options;
+    }
+
+    ingest = (events: Array<object> | object) => {
+        if (Array.isArray(events)) {
+            this.events = this.events.concat(events);
+        } else {
+            this.events.push(events);
+        }
+
+        if (this.events.length >= 1000 || this.lastFlush.getTime() < Date.now() - 1000) {
+            // We either have more than 1k events or the last flush was more than 1s ago
+            clearTimeout(this.nextFlush);
+            this.activeFlush = this.flush();
+        } else {
+            // Create a timeout so we flush remaining events even if no more come in
+            clearTimeout(this.nextFlush);
+            this.nextFlush = setTimeout(() => {
+                this.activeFlush = this.flush();
+            }, 1000);
+        }
+    };
+
+    flush = async (): Promise<IngestStatus | undefined> => {
+        clearTimeout(this.nextFlush);
+        await this.activeFlush;
+
+        if (this.events.length === 0) {
+            this.lastFlush = new Date(); // we tried
+            return;
+        }
+
+        const res = await this.ingestFn(this.id, this.events, this.options);
+        this.events = [];
+        this.lastFlush = new Date();
+        return res;
+    };
+}

--- a/lib/batch.ts
+++ b/lib/batch.ts
@@ -19,7 +19,7 @@ export class Batch {
         this.options = options;
     }
 
-    ingest = (events: Array<object> | object) => {
+    ingestEvents = (events: Array<object> | object) => {
         if (Array.isArray(events)) {
             this.events = this.events.concat(events);
         } else {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,5 +1,6 @@
 import { datasets } from './datasets';
 import { users } from './users';
+import { Batch } from './batch';
 import HTTPClient, { ClientOptions } from './httpClient';
 import { gzip } from 'zlib';
 import { promisify } from 'util';
@@ -64,6 +65,10 @@ export class Client extends HTTPClient {
         const json = array.map((v) => JSON.stringify(v)).join('\n');
         const encoded = await promisify(gzip)(json);
         return this.ingestBuffer(id, encoded, ContentType.NDJSON, ContentEncoding.GZIP, options);
+    };
+
+    createBatch = (id: string, options?: IngestOptions): Batch => {
+        return new Batch(this.ingestEvents, id, options);
     };
 
     queryLegacy = (id: string, query: QueryLegacy, options?: QueryOptions): Promise<QueryLegacyResult> =>

--- a/tests/unit/batch.test.ts
+++ b/tests/unit/batch.test.ts
@@ -1,0 +1,63 @@
+import { fail } from 'assert';
+import { Batch } from '../../lib/batch';
+
+async function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('Batch', () => {
+    it('sends events after 1s', async () => {
+        const sendFn = jest.fn();
+
+        const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
+        batch.ingest({ foo: 'bar' });
+        batch.ingest({ foo: 'baz' });
+
+        await sleep(500);
+        expect(sendFn).toHaveBeenCalledTimes(0);
+        await sleep(600);
+        expect(sendFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends events after 1k events', async () => {
+        const sendFn = jest.fn();
+
+        const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
+
+        let events = [];
+        for (let i = 0; i < 1000; i++) {
+            batch.ingest({ foo: 'bar' });
+        }
+
+        await sleep(100); // just make sure we have enough time
+        expect(sendFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends events after 1s when ingesting one event every 100ms', async () => {
+        const sendFn = jest.fn();
+
+        const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
+
+        for (let i = 0; i < 10; i++) {
+            batch.ingest({ foo: 'bar' });
+            await sleep(120);
+        }
+
+        await sleep(100); // just make sure we have enough time
+        expect(sendFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends events on flush', async () => {
+        const sendFn = jest.fn();
+
+        const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
+
+        for (let i = 0; i < 10; i++) {
+            batch.ingest({ foo: 'bar' });
+        }
+
+        expect(sendFn).toHaveBeenCalledTimes(0);
+        await batch.flush();
+        expect(sendFn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/batch.test.ts
+++ b/tests/unit/batch.test.ts
@@ -11,8 +11,8 @@ describe('Batch', () => {
         const sendFn = jest.fn();
 
         const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
-        batch.ingest({ foo: 'bar' });
-        batch.ingest({ foo: 'baz' });
+        batch.ingestEvents({ foo: 'bar' });
+        batch.ingestEvents({ foo: 'baz' });
 
         expect(sendFn).not.toHaveBeenCalled();
         jest.runAllTimers();
@@ -29,7 +29,7 @@ describe('Batch', () => {
 
         let events = [];
         for (let i = 0; i < 1000; i++) {
-            batch.ingest({ foo: 'bar' });
+            batch.ingestEvents({ foo: 'bar' });
         }
 
         await sleep(100); // just make sure we have enough time
@@ -43,7 +43,7 @@ describe('Batch', () => {
         const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
 
         for (let i = 0; i < 10; i++) {
-            batch.ingest({ foo: 'bar' });
+            batch.ingestEvents({ foo: 'bar' });
             jest.advanceTimersByTime(120);
         }
 
@@ -58,7 +58,7 @@ describe('Batch', () => {
         const batch = new Batch(sendFn, 'my-dataset', { timestampField: 'foo' });
 
         for (let i = 0; i < 10; i++) {
-            batch.ingest({ foo: 'bar' });
+            batch.ingestEvents({ foo: 'bar' });
         }
 
         expect(sendFn).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
This adds batching support to axiom-node, use it like this:

```ts
import { Client } from '@axiomhq/axiom-node';

async function main() {
    const client = new Client();

    const batch = client.createBatch('my-dataset');
    batch.ingestEvents({ foo: 'bar' });
    batch.ingestEvents({ foo: 'bar' });
    batch.ingestEvents({ foo: 'bar' });

    await batch.flush();
}
```

It will automatically send events once the batch has grown to 1k events or every second.