### PR TITLE
Fix: README example of Axiom Transport with Winston

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ formatter, for example like this:
 import winston from 'winston';
 import { WinstonTransport as AxiomTransport } from '@axiomhq/axiom-node';
 
-const { combine, errors, stack } = winston.format;
+const { combine, errors, json } = winston.format;
 
 const axiomTransport = new AxiomTransport({ ... });
 const logger = winston.createLogger({


### PR DESCRIPTION
Fixes a typo in the example where it's destructuring `winston.format`. It should be `combine, errors, json` instead of `combine, errors, stack`.